### PR TITLE
Fix/deploy

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -62,4 +62,4 @@ kube-prometheus-stack:
     defaultDashboardsEnabled: true
   prometheus:
     prometheusSpec:
-      maximumStartupDurationSeconds: 60
+      maximumStartupDurationSeconds: 120

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -60,3 +60,6 @@ kube-prometheus-stack:
     enabled: false
   grafana:
     defaultDashboardsEnabled: true
+  prometheus:
+    prometheusSpec:
+      maximumStartupDurationSeconds: 60


### PR DESCRIPTION
This pull request introduces a configuration update to the `kube-prometheus-stack` in the `helm/values.yaml` file. The change adds a new setting to specify the maximum startup duration for Prometheus.

Configuration update:

* [`helm/values.yaml`](diffhunk://#diff-81801117ec01136c8a49bfcd42af8e104f4efad1f2daccda9da9d960eaad5279R63-R65): Added `prometheus.prometheusSpec.maximumStartupDurationSeconds` with a value of `120` to define the maximum startup duration for Prometheus.